### PR TITLE
Don't call onRender if the window is minimized it will crash.

### DIFF
--- a/Source/modules/window/Win32Window.cpp
+++ b/Source/modules/window/Win32Window.cpp
@@ -160,6 +160,11 @@ bool Win32Window::isClosed()
     return (m_state.windowHandle == nullptr);
 }
 
+bool Win32Window::shouldRender()
+{
+    return (m_state.windowHandle != nullptr) && !IsIconic(m_state.windowHandle);
+}
+
 void Win32Window::open()
 {
     if (isClosed())

--- a/Source/modules/window/Win32Window.h
+++ b/Source/modules/window/Win32Window.h
@@ -28,6 +28,7 @@ public:
     virtual WindowOsHandle getHandle() const override;
     virtual void open() override;
     virtual bool isClosed() override;
+    virtual bool shouldRender() override;
     virtual void dimensions(int& w, int& h) const override;
     virtual ~Win32Window();
 

--- a/Source/modules/window/public/coalpy.window/IWindow.h
+++ b/Source/modules/window/public/coalpy.window/IWindow.h
@@ -16,6 +16,7 @@ public:
     virtual void open() = 0;
     virtual void dimensions(int& w, int& h) const = 0;
     virtual bool isClosed() = 0;
+    virtual bool shouldRender() { return !isClosed(); }
     virtual const WindowInputState& inputState() const = 0;
     virtual ~IWindow() {}
 

--- a/Source/pymodules/gpu/ModuleFunctions.cpp
+++ b/Source/pymodules/gpu/ModuleFunctions.cpp
@@ -290,6 +290,7 @@ PyObject* run(PyObject* self, PyObject* args)
         std::set<Window*> windowsPtrs;
         state.getWindows(windowsPtrs);
         int openedWindows = 0;
+        int renderedWindows = 0;
         for (Window* w : windowsPtrs)
         {
             CPY_ASSERT(w != nullptr);
@@ -298,6 +299,11 @@ PyObject* run(PyObject* self, PyObject* args)
 
             if (w->object->isClosed())
                 continue;
+            ++openedWindows;
+            
+            if (!w->object->shouldRender())
+                continue;
+            ++renderedWindows;
 
             if (w->uiRenderer != nullptr)
             {
@@ -318,7 +324,7 @@ PyObject* run(PyObject* self, PyObject* args)
             Py_INCREF(w->userData);
 
             w->object->dimensions(renderArgs->width, renderArgs->height);
-            ++openedWindows;
+            
             if (w && w->onRenderCallback != nullptr)
             {
                 PyObject* retObj = PyObject_CallOneArg(w->onRenderCallback, (PyObject*)renderArgs);


### PR DESCRIPTION
Adds a window callback for "shouldRender" and respect it. On windows this
translates to IsIconic().